### PR TITLE
Add changelog-widget to Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 
 - [`<active-table>`](https://github.com/OvidijusParsiunas/active-table) - Editable table web component.
 - [`<api-viewer>`](https://github.com/web-padawan/api-viewer-element) - API documentation and live playground for Web Components.
+- [`<changelog-widget>`](https://github.com/NikitaDmitrieff/changelog-widget) - Embeddable changelog widget with Shadow DOM, zero dependencies, and framework-agnostic design.
 - [`<chess-board>`](https://github.com/justinfagnani/chessboard-element) - Standalone chess board web component.
 - [`<css-doodle>`](https://github.com/css-doodle/css-doodle) - Web component for drawing patterns with CSS.
 - [`<dark-mode-toggle>`](https://github.com/GoogleChromeLabs/dark-mode-toggle) - Custom element that allows to create a dark mode toggle or switch.


### PR DESCRIPTION
## Summary

- Add [`<changelog-widget>`](https://github.com/NikitaDmitrieff/changelog-widget) to the **Components** section, in alphabetical order.

## About the Component

**changelogdev-widget** is an embeddable changelog widget built as a native Web Component using Shadow DOM. It has zero dependencies and is fully framework-agnostic — works with React, Vue, Svelte, Angular, or plain HTML.

- **npm**: https://www.npmjs.com/package/changelogdev-widget
- **GitHub**: https://github.com/NikitaDmitrieff/changelog-widget
- **Homepage**: https://www.changelogdev.com
- **License**: MIT

### Key Features

- Built with Custom Elements + Shadow DOM (true encapsulation)
- Zero dependencies
- Framework-agnostic — drop a single `<script>` tag into any page
- Lightweight and production-ready

## Checklist

- [x] Entry uses the existing format: backtick-wrapped tag name, GitHub link, brief description
- [x] Added in alphabetical order (between `<chess-board>` and `<css-doodle>`)
- [x] Spelling and grammar checked
- [x] No duplicate entry