### PR TITLE
Add dirham-symbol web component

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [`<css-doodle>`](https://github.com/css-doodle/css-doodle) - Web component for drawing patterns with CSS.
 - [`<dark-mode-toggle>`](https://github.com/GoogleChromeLabs/dark-mode-toggle) - Custom element that allows to create a dark mode toggle or switch.
 - [`<deep-chat>`](https://github.com/OvidijusParsiunas/deep-chat) - Web component for chat with AI capabilities.
+- [`<dirham-symbol>`](https://github.com/pooyagolchian/dirham) - UAE Dirham currency symbol (U+20C3) as web components with formatting utilities.
 - [`<emoji-picker>`](https://github.com/nolanlawson/emoji-picker-element) - Lightweight emoji picker, distributed as a web component.
 - [`<fg-modal>`](https://github.com/filamentgroup/fg-modal) - Accessible modal dialog web component.
 - [`<file-viewer>`](https://github.com/avipunes/file-viewer) - Web component built with Svelte to view files.


### PR DESCRIPTION
## Summary

- Adds [`<dirham-symbol>`](https://github.com/pooyagolchian/dirham) — a web component for rendering the UAE Dirham currency symbol (U+20C3) from Unicode 18.0.
- The package also includes `<dirham-price>` for formatted price display, along with CSS/SCSS utilities and React components.
- Framework-agnostic: works in Vue, Angular, Svelte, and vanilla HTML.

[Live Demo](https://pooya.blog/dirham/) · [npm](https://www.npmjs.com/package/dirham)