### PR TITLE
Add Burnish Components — Lit 3 structured-data components

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [Blackstone UI](https://github.com/kjantzer/bui) - Web components for creating interfaces by Blackstone Publishing.
 - [Blaze UI Atoms](https://github.com/BlazeSoftware/atoms) - Set of web components powered by Blaze CSS.
 - [Brightspace UI core](https://github.com/BrightspaceUI/core) - Collection of web components for building Brightspace applications.
-- [Burnish Components](https://github.com/danfking/burnish) - 10 Lit 3 web components for rendering structured data as UI — cards, tables, charts, stat bars, forms, pipelines, messages, sections, metrics, actions. Built to drive the [Burnish Explorer](https://burnish-demo.fly.dev) but usable standalone in any app.
+- [Burnish Components](https://github.com/danfking/burnish/tree/main/packages/components) - Web components for rendering MCP tool-call output as UI.
 - [Clever components](https://github.com/CleverCloud/clever-components) - Collection of Web Components made by Clever Cloud.
 - [Curvenote](https://github.com/curvenote/article) - Web components for creating interactive scientific articles.
 - [DataFormsJS](https://github.com/dataformsjs/dataformsjs) - Standalone Components for SPA routing, displaying data from web services, and more.

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [Blackstone UI](https://github.com/kjantzer/bui) - Web components for creating interfaces by Blackstone Publishing.
 - [Blaze UI Atoms](https://github.com/BlazeSoftware/atoms) - Set of web components powered by Blaze CSS.
 - [Brightspace UI core](https://github.com/BrightspaceUI/core) - Collection of web components for building Brightspace applications.
+- [Burnish Components](https://github.com/danfking/burnish) - 10 Lit 3 web components for rendering structured data as UI — cards, tables, charts, stat bars, forms, pipelines, messages, sections, metrics, actions. Built to drive the [Burnish Explorer](https://burnish-demo.fly.dev) but usable standalone in any app.
 - [Clever components](https://github.com/CleverCloud/clever-components) - Collection of Web Components made by Clever Cloud.
 - [Curvenote](https://github.com/curvenote/article) - Web components for creating interactive scientific articles.
 - [DataFormsJS](https://github.com/dataformsjs/dataformsjs) - Standalone Components for SPA routing, displaying data from web services, and more.


### PR DESCRIPTION
Adds [Burnish Components](https://github.com/danfking/burnish) to **Real World → Component Libraries** (placed alphabetically between Brightspace UI core and Clever components).

A 10-component Lit 3 library published standalone on npm as [`@burnishdev/components`](https://www.npmjs.com/package/@burnishdev/components):

cards · tables · charts · stat bars · sections · metrics · messages · forms · actions · pipelines

The components render structured data from arbitrary JSON — originally built to drive the [Burnish Explorer](https://burnish-demo.fly.dev) (a Swagger-UI-style viewer for MCP servers) but published standalone with only a `lit@^3` peer dependency.

**Versioning:** 0.4.x, semver-tracked
**License:** AGPL-3.0
**Distribution:** npm + CDN (esm.sh, jsdelivr)
**Types:** ships `.d.ts`

Quick example — drop-in from CDN:

```html
<script type="module" src="https://esm.sh/@burnishdev/components"></script>
<burnish-card data='{"title":"Revenue","value":"$1.2M","trend":"up"}'></burnish-card>
```

Happy to adjust description length or categorization.