### PR TITLE
Add phantom-ui to Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [`<model-viewer>`](https://github.com/google/model-viewer) - Web component for rendering interactive 3D models.
 - [`<notectl-editor>`](https://github.com/Samyssmile/notectl) - Modern rich text editor with plugin architecture, immutable state, and zero-config framework-agnostic deployment.
 - [`<pdfjs-viewer-element>`](https://github.com/alekswebnet/pdfjs-viewer-element) - Custom element that embeds PDF.js default viewer.
+- [`<phantom-ui>`](https://github.com/Aejkatappaja/phantom-ui) - Skeleton loader that measures your real DOM to render matching shimmer placeholders.
 - [`<player-x>`](https://github.com/playerxo/playerx) - Media player web component.
 - [`<progressive-image>`](https://github.com/andreruffert/progressive-image-element) - Custom element to progressively enhance image placeholders.
 - [`<qr-code>`](https://github.com/bitjson/qr-code) – Web component for rendering customizable, animate-able, SVG-based QR codes.


### PR DESCRIPTION
Adds phantom-ui under Real World > Components, in alphabetical order.

phantom-ui is a structure-aware skeleton loader. It wraps your real markup, measures the position and size of each leaf element, and overlays shimmer placeholders at the same coordinates, so the skeleton matches the real layout with no separate skeleton component to maintain.

- Built with Lit, works in React, Vue, Svelte, Angular, Solid, Qwik, and plain HTML
- Accessible: aria-busy, configurable label, and prefers-reduced-motion support (WCAG 2.3.3)
- Shadow DOM piercing and global theming via CSS custom properties
- 635 stars, zero runtime dependencies beyond Lit

Entry follows the existing format and sits alphabetically between pdfjs-viewer-element and player-x.