### PR TITLE
Add AsciiTheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [AMP](https://github.com/ampproject/amphtml) - Web component framework for easily creating user-first websites, stories, ads, emails and more.
 - [AnywhereUI](https://github.com/adaleks/anywhere-ui) - Collection of rich web components that includes framework bindings. Created with StencilJS.
 - [Apollo Elements](https://github.com/apollo-elements/apollo-elements) - Custom elements for using Apollo GraphQL with various web components libraries.
+- [AsciiTheme](https://github.com/markoblogo/AsciiTheme) - ASCII visual layer with a native `<ascii-theme-toggle>` custom element plus React and Vue wrappers.
 - [AXA Pattern Library](https://github.com/axa-ch-webhub-cloud/pattern-library) - AXA CH UI components library built with Web Components.
 - [Blackstone UI](https://github.com/kjantzer/bui) - Web components for creating interfaces by Blackstone Publishing.
 - [Blaze UI Atoms](https://github.com/BlazeSoftware/atoms) - Set of web components powered by Blaze CSS.


### PR DESCRIPTION
## Summary
- add AsciiTheme to the ecosystem list

## Why it fits
AsciiTheme ships a native `<ascii-theme-toggle>` custom element and is usable as a web-components-friendly theme layer, with additional React and Vue wrappers.

## LLM disclosure
I used Codex as an editing assistant and reviewed the final diff before submitting.
