### PR TITLE
Add sitelen-layer-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [AMP](https://github.com/ampproject/amphtml) - Web component framework for easily creating user-first websites, stories, ads, emails and more.
 - [AnywhereUI](https://github.com/adaleks/anywhere-ui) - Collection of rich web components that includes framework bindings. Created with StencilJS.
 - [Apollo Elements](https://github.com/apollo-elements/apollo-elements) - Custom elements for using Apollo GraphQL with various web components libraries.
+- [AsciiTheme](https://github.com/markoblogo/AsciiTheme) - ASCII visual layer with a native `<ascii-theme-toggle>` custom element plus React and Vue wrappers.
 - [AXA Pattern Library](https://github.com/axa-ch-webhub-cloud/pattern-library) - AXA CH UI components library built with Web Components.
 - [Blackstone UI](https://github.com/kjantzer/bui) - Web components for creating interfaces by Blackstone Publishing.
 - [Blaze UI Atoms](https://github.com/BlazeSoftware/atoms) - Set of web components powered by Blaze CSS.

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [Apollo Elements](https://github.com/apollo-elements/apollo-elements) - Custom elements for using Apollo GraphQL with various web components libraries.
 - [AsciiTheme](https://github.com/markoblogo/AsciiTheme) - ASCII visual layer with a native `<ascii-theme-toggle>` custom element plus React and Vue wrappers.
 - [AXA Pattern Library](https://github.com/axa-ch-webhub-cloud/pattern-library) - AXA CH UI components library built with Web Components.
+- [sitelen-layer-plugin](https://github.com/markoblogo/sitelen-layer-plugin) - Toki pona display-layer plugin with custom-element-friendly integration surface and framework adapters.
 - [Blackstone UI](https://github.com/kjantzer/bui) - Web components for creating interfaces by Blackstone Publishing.
 - [Blaze UI Atoms](https://github.com/BlazeSoftware/atoms) - Set of web components powered by Blaze CSS.
 - [Brightspace UI core](https://github.com/BrightspaceUI/core) - Collection of web components for building Brightspace applications.


### PR DESCRIPTION
## Summary
- add sitelen-layer-plugin to the ecosystem list

## Why it fits
sitelen-layer-plugin is a display-layer plugin with a component-friendly frontend integration surface and adapters across modern web frameworks.

## LLM disclosure
I used Codex as an editing assistant and reviewed the final diff before submitting.
