### PR TITLE
Add <lit-isoflow> to Real World / Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [`<fg-modal>`](https://github.com/filamentgroup/fg-modal) - Accessible modal dialog web component.
 - [`<file-viewer>`](https://github.com/avipunes/file-viewer) - Web component built with Svelte to view files.
 - [`<json-viewer>`](https://github.com/alenaksu/json-viewer) - Web component to visualize JSON data in a tree view.
+- [`<lit-isoflow>`](https://github.com/eviltik/lit-isoflow) - Viewer and editor for isometric infrastructure diagrams, with a DOM-free SVG renderer for export pipelines.
 - [`<lite-youtube>`](https://github.com/paulirish/lite-youtube-embed) - Lite YouTube embed with a focus on visual performance.
 - [`<midi-player>`](https://github.com/cifkao/html-midi-player) - MIDI file player and visualizer web components.
 - [`<model-viewer>`](https://github.com/google/model-viewer) - Web component for rendering interactive 3D models.


### PR DESCRIPTION
Adds [`<lit-isoflow>`](https://github.com/eviltik/lit-isoflow) under **Real World → Components**, in alphabetical order.

A viewer and editor for isometric infrastructure diagrams — a React-free port of [Isoflow](https://github.com/markmanx/isoflow)/FossFLOW as a single Lit element. Upstream is a React app (React, MUI, zustand, immer, gsap, react-quill), so it cannot be embedded outside React; this keeps the isometric projection, the A* connector routing and the model format (JSON, interchangeable with Isoflow/FossFLOW), and rewrites the view layer as a custom element. Three runtime dependencies: `lit`, `zod`, `pathfinding`.

Notable beyond "another wrapper":

- **A DOM-free SVG renderer** ships alongside the element (`lit-isoflow/render`), sharing its geometry engine — so the same diagram renders identically in the browser and in a Node pipeline (PDF, docs, CI), with no headless browser.
- Three modes on one element: viewer, editor, and static rendering.
- MIT, [live demos](https://eviltik.github.io/lit-isoflow/), unit tests in CI, [integration guide](https://github.com/eviltik/lit-isoflow/blob/master/docs/integration.md), published as [`lit-isoflow`](https://www.npmjs.com/package/lit-isoflow) on npm.

There is currently no diagramming component in the list, so this fills a gap rather than duplicating an entry.