### PR TITLE
Add Bellnote Widget to Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 
 - [`<active-table>`](https://github.com/OvidijusParsiunas/active-table) - Editable table web component.
 - [`<api-viewer>`](https://github.com/web-padawan/api-viewer-element) - API documentation and live playground for Web Components.
+- [Bellnote Widget](https://github.com/Trooper15a/bellnote-widget) - Embeddable changelog widget with bell launcher and unread badge, under 5 KB gzipped, no cookies.
 - [`<chess-board>`](https://github.com/justinfagnani/chessboard-element) - Standalone chess board web component.
 - [`<css-doodle>`](https://github.com/css-doodle/css-doodle) - Web component for drawing patterns with CSS.
 - [`<dark-mode-toggle>`](https://github.com/GoogleChromeLabs/dark-mode-toggle) - Custom element that allows to create a dark mode toggle or switch.


### PR DESCRIPTION
Adds Bellnote Widget, an MIT-licensed embeddable changelog widget (<5KB, no cookies).

Entry follows the list format and sits alphabetically between `<api-viewer>` and `<chess-board>` in Real World > Components. Note: it is a script-tag widget written in dependency-free vanilla TypeScript rather than a registered custom element, so it is listed by name instead of a `<tag>`. Happy to move or remove it if you feel it does not fit the section.