### PR TITLE
Add `<aura-router>`  to Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 
 - [`<active-table>`](https://github.com/OvidijusParsiunas/active-table) - Editable table web component.
 - [`<api-viewer>`](https://github.com/web-padawan/api-viewer-element) - API documentation and live playground for Web Components.
-- [`<aura-router>`](https://github.com/aura-ui/router) - Adds client (SPA) navigation to HTML pages.
+- [`<aura-router>`](https://github.com/aura-ui/router) - HTML-first client-side router web component.
 - [`<chess-board>`](https://github.com/justinfagnani/chessboard-element) - Standalone chess board web component.
 - [`<css-doodle>`](https://github.com/css-doodle/css-doodle) - Web component for drawing patterns with CSS.
 - [`<dark-mode-toggle>`](https://github.com/GoogleChromeLabs/dark-mode-toggle) - Custom element that allows to create a dark mode toggle or switch.

--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 ### Components
 
 - [`<active-table>`](https://github.com/OvidijusParsiunas/active-table) - Editable table web component.
-- - [<aura-router>](https://github.com/aura-ui/router) - Adds client(SPA) navigation to HTML pages.
 - [`<api-viewer>`](https://github.com/web-padawan/api-viewer-element) - API documentation and live playground for Web Components.
+- [<aura-router>](https://github.com/aura-ui/router) - Adds client(SPA) navigation to HTML pages.
 - [`<chess-board>`](https://github.com/justinfagnani/chessboard-element) - Standalone chess board web component.
 - [`<css-doodle>`](https://github.com/css-doodle/css-doodle) - Web component for drawing patterns with CSS.
 - [`<dark-mode-toggle>`](https://github.com/GoogleChromeLabs/dark-mode-toggle) - Custom element that allows to create a dark mode toggle or switch.

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [AMP](https://github.com/ampproject/amphtml) - Web component framework for easily creating user-first websites, stories, ads, emails and more.
 - [AnywhereUI](https://github.com/adaleks/anywhere-ui) - Collection of rich web components that includes framework bindings. Created with StencilJS.
 - [Apollo Elements](https://github.com/apollo-elements/apollo-elements) - Custom elements for using Apollo GraphQL with various web components libraries.
-- [Aura Router](https://github.com/aura-ui/router) - HTML-first client-side router as Web Components; upgrade static MPA pages to SPA navigation without a framework rewrite.
+- [Aura Router](https://github.com/aura-ui/router) - Keep the HTML. Upgrade the navigation. HTML-first client navigation for complete pages — plain HTML or Web Components.
 - [AXA Pattern Library](https://github.com/axa-ch-webhub-cloud/pattern-library) - AXA CH UI components library built with Web Components.
 - [Blackstone UI](https://github.com/kjantzer/bui) - Web components for creating interfaces by Blackstone Publishing.
 - [Blaze UI Atoms](https://github.com/BlazeSoftware/atoms) - Set of web components powered by Blaze CSS.

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 
 - [`<active-table>`](https://github.com/OvidijusParsiunas/active-table) - Editable table web component.
 - [`<api-viewer>`](https://github.com/web-padawan/api-viewer-element) - API documentation and live playground for Web Components.
-- [<aura-router>](https://github.com/aura-ui/router) - Adds client(SPA) navigation to HTML pages.
+- [`<aura-router>`](https://github.com/aura-ui/router) - Adds client(SPA) navigation to HTML pages.
 - [`<chess-board>`](https://github.com/justinfagnani/chessboard-element) - Standalone chess board web component.
 - [`<css-doodle>`](https://github.com/css-doodle/css-doodle) - Web component for drawing patterns with CSS.
 - [`<dark-mode-toggle>`](https://github.com/GoogleChromeLabs/dark-mode-toggle) - Custom element that allows to create a dark mode toggle or switch.

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 
 - [`<active-table>`](https://github.com/OvidijusParsiunas/active-table) - Editable table web component.
 - [`<api-viewer>`](https://github.com/web-padawan/api-viewer-element) - API documentation and live playground for Web Components.
-- [`<aura-router>`](https://github.com/aura-ui/router) - Adds client(SPA) navigation to HTML pages.
+- [`<aura-router>`](https://github.com/aura-ui/router) - Adds client (SPA) navigation to HTML pages.
 - [`<chess-board>`](https://github.com/justinfagnani/chessboard-element) - Standalone chess board web component.
 - [`<css-doodle>`](https://github.com/css-doodle/css-doodle) - Web component for drawing patterns with CSS.
 - [`<dark-mode-toggle>`](https://github.com/GoogleChromeLabs/dark-mode-toggle) - Custom element that allows to create a dark mode toggle or switch.

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 ### Components
 
 - [`<active-table>`](https://github.com/OvidijusParsiunas/active-table) - Editable table web component.
+- - [<aura-router>](https://github.com/aura-ui/router) - Adds client(SPA) navigation to HTML pages.
 - [`<api-viewer>`](https://github.com/web-padawan/api-viewer-element) - API documentation and live playground for Web Components.
 - [`<chess-board>`](https://github.com/justinfagnani/chessboard-element) - Standalone chess board web component.
 - [`<css-doodle>`](https://github.com/css-doodle/css-doodle) - Web component for drawing patterns with CSS.
@@ -287,7 +288,6 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [AMP](https://github.com/ampproject/amphtml) - Web component framework for easily creating user-first websites, stories, ads, emails and more.
 - [AnywhereUI](https://github.com/adaleks/anywhere-ui) - Collection of rich web components that includes framework bindings. Created with StencilJS.
 - [Apollo Elements](https://github.com/apollo-elements/apollo-elements) - Custom elements for using Apollo GraphQL with various web components libraries.
-- [Aura Router](https://github.com/aura-ui/router) - Keep the HTML. Upgrade the navigation. HTML-first client navigation for complete pages — plain HTML or Web Components.
 - [AXA Pattern Library](https://github.com/axa-ch-webhub-cloud/pattern-library) - AXA CH UI components library built with Web Components.
 - [Blackstone UI](https://github.com/kjantzer/bui) - Web components for creating interfaces by Blackstone Publishing.
 - [Blaze UI Atoms](https://github.com/BlazeSoftware/atoms) - Set of web components powered by Blaze CSS.

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [AMP](https://github.com/ampproject/amphtml) - Web component framework for easily creating user-first websites, stories, ads, emails and more.
 - [AnywhereUI](https://github.com/adaleks/anywhere-ui) - Collection of rich web components that includes framework bindings. Created with StencilJS.
 - [Apollo Elements](https://github.com/apollo-elements/apollo-elements) - Custom elements for using Apollo GraphQL with various web components libraries.
+- [Aura Router](https://github.com/aura-ui/router) - HTML-first client-side router as Web Components; upgrade static MPA pages to SPA navigation without a framework rewrite.
 - [AXA Pattern Library](https://github.com/axa-ch-webhub-cloud/pattern-library) - AXA CH UI components library built with Web Components.
 - [Blackstone UI](https://github.com/kjantzer/bui) - Web components for creating interfaces by Blackstone Publishing.
 - [Blaze UI Atoms](https://github.com/BlazeSoftware/atoms) - Set of web components powered by Blaze CSS.


### PR DESCRIPTION
Adds [`<aura-router>`](https://github.com/aura-ui/router) to Components — HTML-first client-side router as Web Components.

It upgrades ordinary HTML pages to SPA navigation without a framework rewrite. Routes are declared in markup; the host still serves complete pages, and Aura intercepts marked links after load:

```html
<aura-router extract="#content">
  <aura-route path="/" view="/"></aura-route>
  <aura-route path="/about/" view="/about/"></aura-route>
</aura-router>
```
Nested layouts keep shared chrome mounted while child views change:

```
<template id="workspace-shell">
  <workspace-sidebar></workspace-sidebar>
  <aura-outlet></aura-outlet>
</template>

<aura-route path="/workspace/" layout="workspace-shell">
  <aura-route path="." view="/workspace/"></aura-route>
  <aura-route path="settings" view="/workspace/settings/"></aura-route>
</aura-route>
```
Also includes lifecycle hooks (guard, load, ready, leave), multiple view sources, prefetch, and caching.

- Demo: https://aura-ui.github.io/router-preview/
- Repo: https://github.com/aura-ui/router
- npm: https://www.npmjs.com/package/@auraui/router
- License: MIT
