### PR TITLE
Add PlayCanvas Web Components to Component Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [One Platform Components](https://github.com/1-Platform/op-components) - Set of web components for Red Hat One Platform.
 - [Open Business Application Platform Web Components](https://github.com/openbap/obap-elements) - Collection of web components designed for business applications.
 - [Pixano Elements](https://github.com/pixano/pixano-elements) - Re-usable web components dedicated to data annotation tasks.
+- [PlayCanvas Web Components](https://github.com/playcanvas/web-components) - Custom elements for building 3D interactive web apps with the PlayCanvas Engine.
 - [Playground Elements](https://github.com/PolymerLabs/playground-elements) - Serverless code experiences with web components.
 - [Shoelace](https://github.com/shoelace-style/shoelace) - A forward-thinking library of web components.
 - [Smart Web Components](https://github.com/HTMLElements/smart-webcomponents) - Web components for business applications.


### PR DESCRIPTION
Adds [PlayCanvas Web Components](https://github.com/playcanvas/web-components) to **Real World › Component Libraries**.

A set of custom elements for building 3D interactive web apps, rendered by the [PlayCanvas Engine](https://github.com/playcanvas/engine) via WebGL and WebGPU. The scene graph, materials, lighting, physics, particles, UI, WebXR and Gaussian splats are all authored declaratively in HTML:

```html
<pc-app>
    <pc-scene>
        <pc-entity name="camera" position="0 0 3">
            <pc-camera></pc-camera>
        </pc-entity>
        <pc-entity name="light" rotation="45 45 0">
            <pc-light></pc-light>
        </pc-entity>
        <pc-entity name="ball">
            <pc-render type="sphere"></pc-render>
        </pc-entity>
    </pc-scene>
</pc-app>
```

MIT licensed and published to npm as [`@playcanvas/web-components`](https://www.npmjs.com/package/@playcanvas/web-components). It ships a [Custom Elements Manifest](https://github.com/webcomponents/custom-elements-manifest) (plus VS Code custom data and JetBrains `web-types`), so editors offer tag/attribute completions and hover docs when authoring HTML.

- [Examples](https://playcanvas.github.io/web-components/examples)
- [User Manual](https://developer.playcanvas.com/user-manual/web-components/)
- [API Reference](https://api.playcanvas.com/web-components)

Per the contribution guidelines:

- [x] Searched previous suggestions — no existing entry, issue or PR mentions PlayCanvas
- [x] Uses the `[Name](link) - Description.` format
- [x] Title-cased name, no leading `A`/`An` in the description
- [x] Added to the relevant category in alphabetical order (between Pixano Elements and Playground Elements)
- [x] Checked spelling and grammar
