### PR TITLE
Add `<emoji-clock>` to Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [`<css-doodle>`](https://github.com/css-doodle/css-doodle) - Web component for drawing patterns with CSS.
 - [`<dark-mode-toggle>`](https://github.com/GoogleChromeLabs/dark-mode-toggle) - Custom element that allows to create a dark mode toggle or switch.
 - [`<deep-chat>`](https://github.com/OvidijusParsiunas/deep-chat) - Web component for chat with AI capabilities.
+- [`<emoji-clock>`](https://github.com/xoocode/emoji-clock-element) - Clock face that reads the time as an emoji, rounded to the nearest half hour, for any timezone.
 - [`<emoji-picker>`](https://github.com/nolanlawson/emoji-picker-element) - Lightweight emoji picker, distributed as a web component.
 - [`<fg-modal>`](https://github.com/filamentgroup/fg-modal) - Accessible modal dialog web component.
 - [`<file-viewer>`](https://github.com/avipunes/file-viewer) - Web component built with Svelte to view files.


### PR DESCRIPTION
Adds `<emoji-clock>`, a custom element that reads the time as an emoji clock face, rounded to the nearest half hour, for any timezone.

- Repo: https://github.com/xoocode/emoji-clock-element
- npm: https://www.npmjs.com/package/emoji-clock-element
- Demo: https://eeemoji.com/clock

It is a real custom element, not a wrapper: vanilla JS, no dependencies, no build step, Shadow DOM for isolation, and five exposed CSS parts. Around 8 KB, and it fetches nothing at runtime.

Inserted alphabetically in Components, between `<deep-chat>` and `<emoji-picker>`. One line added, nothing else touched.