### PR TITLE
Add <yard-material-coverage> to Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [`<trix-editor>`](https://github.com/basecamp/trix) - Rich text editor custom element for everyday writing.
 - [`<vime-player>`](https://github.com/vime-js/vime) - Customizable, extensible, accessible and framework agnostic media player.
 - [`<web-vitals>`](https://github.com/stefanjudis/web-vitals-element) - Bring [web vitals](https://github.com/GoogleChrome/web-vitals) quickly into your page using custom elements.
+- [`<yard-material-coverage>`](https://github.com/demi-valerith/yard-material-coverage-data) - Privacy-friendly landscape material calculator with configurable units and source data.
 
 ### Component Libraries
 


### PR DESCRIPTION
Adds `<yard-material-coverage>` to the alphabetized Components section.

The package provides a standalone custom element for landscape material coverage calculations, supports configurable units, and publishes its source data and implementation in the linked repository.