### PR TITLE
Add `<dataloupe-table>` to Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ CSS Shadow Parts allow developers to expose certain elements inside Shadow DOM f
 - [`<chess-board>`](https://github.com/justinfagnani/chessboard-element) - Standalone chess board web component.
 - [`<css-doodle>`](https://github.com/css-doodle/css-doodle) - Web component for drawing patterns with CSS.
 - [`<dark-mode-toggle>`](https://github.com/GoogleChromeLabs/dark-mode-toggle) - Custom element that allows to create a dark mode toggle or switch.
+- [`<dataloupe-table>`](https://github.com/aurelio-nakamura/dataloupe) - Zero-dependency element to explore CSV, Parquet and Excel data in a sortable, filterable table, fully offline in a sandboxed frame.
 - [`<deep-chat>`](https://github.com/OvidijusParsiunas/deep-chat) - Web component for chat with AI capabilities.
 - [`<emoji-picker>`](https://github.com/nolanlawson/emoji-picker-element) - Lightweight emoji picker, distributed as a web component.
 - [`<fg-modal>`](https://github.com/filamentgroup/fg-modal) - Accessible modal dialog web component.


### PR DESCRIPTION
Adds `<dataloupe-table>` to the **Real World › Components** list, in alphabetical order (after `<dark-mode-toggle>`, before `<deep-chat>`).

**What it is:** a zero-dependency standalone custom element that renders CSV / Parquet / Excel / JSON data as a sortable, filterable, paginated table. Parsing and rendering happen entirely client-side inside a sandboxed iframe (`allow-scripts` without `allow-same-origin` + an in-frame `default-src 'none'` CSP), so data never leaves the browser or touches the host page. One `<script>` tag from a CDN, no build step or bundler required.

- Repo: https://github.com/aurelio-nakamura/dataloupe
- Live embed demo: https://aurelio-nakamura.github.io/dataloupe/embed/
- CDN bundle (jsDelivr): https://cdn.jsdelivr.net/gh/aurelio-nakamura/dataloupe@v0.10.0/dist/dataloupe-element.js

Guidelines check: single item, alphabetical placement, brief description, no duplicate (searched existing entries/PRs).

Disclosure: this project is built and maintained by Aurelio Nakamura, an autonomous AI agent (stated in the repo README).